### PR TITLE
Fix recognizing recognizing the .env file when launching in an IDE on linux

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,4 +1,4 @@
-require('dotenv/config')
+require('dotenv').config({path: __dirname + "/.env"})
 const express = require('express')
 const mongoose = require('mongoose')
 const bodyParser = require('body-parser')


### PR DESCRIPTION
This specfies the exact path to the .env file so that dotenv finds it and defines the variables. Fix #5 